### PR TITLE
added role-based BuildType tests

### DIFF
--- a/src/test/java/com/examle/teamcity/api/BuildTypeTest.java
+++ b/src/test/java/com/examle/teamcity/api/BuildTypeTest.java
@@ -3,6 +3,7 @@ package com.example.teamcity.api;
 import com.examle.teamcity.api.BaseApiTest;
 import com.example.teamcity.api.models.BuildType;
 import com.example.teamcity.api.models.Project;
+import com.example.teamcity.api.models.Roles;
 import com.example.teamcity.api.models.User;
 import com.example.teamcity.api.requests.CheckedRequests;
 import com.example.teamcity.api.requests.unchecked.UncheckedBase;
@@ -15,7 +16,6 @@ import java.util.Arrays;
 
 import static com.example.teamcity.api.enums.Endpoint.*;
 import static com.example.teamcity.api.generators.TestDataGenerator.generate;
-import static io.qameta.allure.Allure.step;
 
 @Test(groups = {"Regression"})
 public class BuildTypeTest extends BaseApiTest {
@@ -52,25 +52,38 @@ public class BuildTypeTest extends BaseApiTest {
 
     @Test(description = "Project admin should be able to create build type for their project", groups = {"Positive", "Roles"})
     public void projectAdminCreatesBuildTypeTest() {
-        step("Create user");
-        step("Create project");
-        step("Grant user PROJECT_ADMIN role in project");
+        superUserCheckRequests.getRequest(PROJECTS).create(testData.getProject());
 
-        step("Create buildType for project by user (PROJECT_ADMIN)");
-        step("Check buildType was created successfully");
+        testData.getUser().setRoles(generate(Roles.class, "PROJECT_ADMIN", "p:" + testData.getProject().getId()));
+        superUserCheckRequests.getRequest(USERS).create(testData.getUser());
+
+        var userCheckRequests = new CheckedRequests(Specifications.authSpec(testData.getUser()));
+
+        userCheckRequests.getRequest(BUILD_TYPES).create(testData.getBuildType());
+
+        var createdBuildType = userCheckRequests.<BuildType>getRequest(BUILD_TYPES).read(testData.getBuildType().getId());
+
+        softy.assertEquals(testData.getBuildType().getName(), createdBuildType.getName(), "Build type name is not correct");
+
     }
 
     @Test(description = "Project admin should not be able to create build type for not their project", groups = {"Negative", "Roles"})
     public void projectAdminCreatesBuildTypeForAnotherUserProjectTest() {
-        step("Create user1");
-        step("Create project1");
-        step("Grant user1 PROJECT_ADMIN role in project1");
+        superUserCheckRequests.getRequest(PROJECTS).create(testData.getProject());
+        testData.getUser().setRoles(generate(Roles.class, "PROJECT_ADMIN", "p:" + testData.getProject().getId()));
+        superUserCheckRequests.getRequest(USERS).create(testData.getUser());
 
-        step("Create user2");
-        step("Create project2");
-        step("Grant user2 PROJECT_ADMIN role in project2");
+        var secondProject = generate(Project.class);
+        superUserCheckRequests.getRequest(PROJECTS).create(secondProject);
+        var secondUser = generate(User.class);
+        secondUser.setRoles(generate(Roles.class, "PROJECT_ADMIN", "p:" + secondProject.getId()));
+        superUserCheckRequests.getRequest(USERS).create(secondUser);
 
-        step("Create buildType for project1 by user2");
-        step("Check buildType was not created with forbidden code");
+        var userCheckRequests = new CheckedRequests(Specifications.authSpec(secondUser));
+        var response = new UncheckedBase(Specifications.authSpec(secondUser), BUILD_TYPES)
+                .create(testData.getBuildType());
+
+        response.then().assertThat().statusCode(HttpStatus.SC_FORBIDDEN)
+                .body(Matchers.containsString("You do not have enough permissions to edit project with id: %s".formatted(testData.getProject().getId())));
     }
 }


### PR DESCRIPTION
1. В тесте `projectAdminCreatesBuildTypeTest` я проверяю, что администратор может создать сборку для своего проекта. Для этого я создаю проект, назначаю пользователю роль администратора и проверяю, что сборка создана правильно.

2. В тесте `projectAdminCreatesBuildTypeForAnotherUserProjectTest` я проверяю, что администратор не может создавать сборки для чужого проекта. Я создаю второй проект с другим администратором и проверяю, что при попытке создать сборку для чужого проекта система выдаёт ошибку.