### PR TITLE
feat: added BuildConfigurationPage, BuildTypeElement, BuildTypePage, CreateBuildTypePage, CreateBuildTypeTest, and @BeforeMethod in BaseUiTest for autotests

### DIFF
--- a/src/main/java/com/example/teamcity/api/requests/Request.java
+++ b/src/main/java/com/example/teamcity/api/requests/Request.java
@@ -3,7 +3,7 @@ package com.example.teamcity.api.requests;
 import com.example.teamcity.api.enums.Endpoint;
 import io.restassured.specification.RequestSpecification;
 
-public class Request {
+public abstract class Request {
     protected final RequestSpecification spec;
     protected final Endpoint endpoint;
 

--- a/src/main/java/com/example/teamcity/api/requests/checked/CheckedBase.java
+++ b/src/main/java/com/example/teamcity/api/requests/checked/CheckedBase.java
@@ -5,6 +5,7 @@ import com.example.teamcity.api.models.BaseModel;
 import com.example.teamcity.api.requests.CrudInterface;
 import com.example.teamcity.api.requests.Request;
 import com.example.teamcity.api.requests.unchecked.UncheckedBase;
+import io.restassured.response.Response;
 import io.restassured.specification.RequestSpecification;
 import org.apache.http.HttpStatus;
 

--- a/src/main/java/com/example/teamcity/api/requests/unchecked/UncheckedBase.java
+++ b/src/main/java/com/example/teamcity/api/requests/unchecked/UncheckedBase.java
@@ -29,6 +29,7 @@ public class UncheckedBase extends Request implements CrudInterface {
         return RestAssured
                 .given()
                 .spec(spec)
+                .when()
                 .get(endpoint.getUrl() + "/" + locator);
     }
 

--- a/src/main/java/com/example/teamcity/ui/elements/BuildTypeElement.java
+++ b/src/main/java/com/example/teamcity/ui/elements/BuildTypeElement.java
@@ -1,0 +1,14 @@
+package com.example.teamcity.ui.elements;
+
+import com.codeborne.selenide.SelenideElement;
+import lombok.Getter;
+
+@Getter
+public class BuildTypeElement extends BasePageElement {
+    private SelenideElement name;
+
+    public BuildTypeElement(SelenideElement element) {
+        super(element);
+        this.name = find("span[class*='MiddleEllipsis__searchable--uZ']");
+    }
+}

--- a/src/main/java/com/example/teamcity/ui/pages/admin/BuildConfigurationPage.java
+++ b/src/main/java/com/example/teamcity/ui/pages/admin/BuildConfigurationPage.java
@@ -1,0 +1,12 @@
+package com.example.teamcity.ui.pages.admin;
+
+import com.codeborne.selenide.Selenide;
+import com.example.teamcity.ui.pages.BasePage;
+
+public class BuildConfigurationPage extends BasePage {
+    private static final String BUILD_TYPE_URL = "/buildConfiguration/%s";
+
+    public static BuildConfigurationPage open(String configId) {
+        return Selenide.open(BUILD_TYPE_URL.formatted(configId), BuildConfigurationPage.class);
+    }
+}

--- a/src/main/java/com/example/teamcity/ui/pages/admin/BuildTypePage.java
+++ b/src/main/java/com/example/teamcity/ui/pages/admin/BuildTypePage.java
@@ -1,0 +1,16 @@
+package com.example.teamcity.ui.pages;
+
+import com.codeborne.selenide.Selenide;
+import com.codeborne.selenide.SelenideElement;
+
+import static com.codeborne.selenide.Selenide.$;
+
+public class BuildTypePage extends BasePage{
+    private static final String BUILD_TYPE_URL = "/admin/discoverRunners.html?init=1&id=buildType:%s";
+
+    public SelenideElement title = $("div[class*='selected buildType']");
+
+    public static BuildTypePage open(String buildTypeId) {
+        return Selenide.open(BUILD_TYPE_URL.formatted(buildTypeId), BuildTypePage.class);
+    }
+}

--- a/src/main/java/com/example/teamcity/ui/pages/admin/CreateBuildTypePage.java
+++ b/src/main/java/com/example/teamcity/ui/pages/admin/CreateBuildTypePage.java
@@ -1,0 +1,36 @@
+package com.example.teamcity.ui.pages.admin;
+
+import com.codeborne.selenide.Condition;
+import com.codeborne.selenide.Selenide;
+import com.codeborne.selenide.SelenideElement;
+
+import static com.codeborne.selenide.Selenide.$;
+
+public class CreateBuildTypePage extends CreateBasePage{
+    private static final String BUILD_TYPE_SHOW_MODE = "createBuildTypeMenu";
+
+    private SelenideElement successfulMessage = $("#unprocessed_objectsCreated");
+    private SelenideElement errorEmptyBuildTypeName =  $("#error_buildTypeName");
+
+    public static CreateBuildTypePage open(String projectId) {
+        return Selenide.open(CREATE_URL.formatted(projectId, BUILD_TYPE_SHOW_MODE), CreateBuildTypePage.class);
+
+    }
+
+    public CreateBuildTypePage createForm(String url){
+        baseCreateForm(url);
+        return this;
+    }
+
+    public void setupBuildType (String buildTypeName) {
+        buildTypeNameInput.val(buildTypeName);
+        submitButton.click();
+        successfulMessage.should(Condition.visible, BASE_WAITING);
+    }
+
+    public void errorMessageEmptyBuildTypeName(String buildTypeName) {
+        buildTypeNameInput.val(buildTypeName);
+        submitButton.click();
+        errorEmptyBuildTypeName.should(Condition.visible);
+    }
+}

--- a/src/test/java/com/example/teamcity/ui/BaseUiTest.java
+++ b/src/test/java/com/example/teamcity/ui/BaseUiTest.java
@@ -1,12 +1,14 @@
-package com.examle.teamcity.ui;
+package com.example.teamcity.ui;
 
 import com.codeborne.selenide.Selenide;
-import com.examle.teamcity.BaseTest;
+import com.example.teamcity.BaseTest;
 import com.example.teamcity.api.config.Config;
 import com.example.teamcity.api.enums.Endpoint;
+import com.example.teamcity.api.generators.TestDataStorage;
 import com.example.teamcity.api.models.User;
 import com.example.teamcity.ui.pages.LoginPage;
 import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.BeforeSuite;
 
 import java.util.Map;
@@ -24,8 +26,16 @@ public class BaseUiTest extends BaseTest {
         browserCapabilities.setCapability("selenoid:options", Map.of("enableVNC", true, "enableLog", true));
     }
 
+    protected TestDataStorage testDataStorage;
+
+    @BeforeMethod(alwaysRun = true)
+    public void setUp() {
+        testDataStorage = TestDataStorage.getStorage();
+    }
+
     @AfterMethod(alwaysRun = true)
-    public void closeWebDriver() {
+    public void tearDown() {
+        testDataStorage.deleteCreatedEntities();
         Selenide.closeWebDriver();
     }
 

--- a/src/test/java/com/example/teamcity/ui/CreateBuildTypeTest.java
+++ b/src/test/java/com/example/teamcity/ui/CreateBuildTypeTest.java
@@ -1,0 +1,60 @@
+package com.example.teamcity.ui;
+
+import com.codeborne.selenide.Condition;
+import com.example.teamcity.api.enums.Endpoint;
+import com.example.teamcity.api.models.BuildType;
+import com.example.teamcity.api.models.Project;
+import com.example.teamcity.api.requests.CheckedRequests;
+import com.example.teamcity.api.spec.Specifications;
+import com.example.teamcity.ui.pages.BuildTypePage;
+import com.example.teamcity.ui.pages.admin.CreateBuildTypePage;
+import org.testng.annotations.Test;
+
+import static com.example.teamcity.api.enums.Endpoint.PROJECTS;
+
+@Test(groups = {"Regression"})
+public class CreateBuildTypeTest extends BaseUiTest {
+    private static final String REPO_URL = "https://github.com/belousovanya/file-parsing-tests";
+
+    @Test(description = "User should be able to create buildType", groups = {"Positive"})
+    public void userCreatesBuildType() {
+        // Подготовка окружения
+        loginAs(testData.getUser());
+        var userCheckRequests = new CheckedRequests(Specifications.authSpec(testData.getUser()));
+
+        // Создание проекта через API
+        userCheckRequests.<Project>getRequest(PROJECTS).create(testData.getProject());
+        testDataStorage.addCreatedEntity(Endpoint.PROJECTS, testData.getProject());
+
+        // Взаимодействие с UI
+        CreateBuildTypePage.open(testData.getProject().getId())
+                .createForm(REPO_URL)
+                .setupBuildType(testData.getBuildType().getName());
+
+        // Получение созданного BuildType через API
+        var createdBuildType = superUserCheckRequests.<BuildType>getRequest(Endpoint.BUILD_TYPES)
+                .read("name:" + testData.getBuildType().getName());
+        softy.assertNotNull(createdBuildType);
+        testDataStorage.addCreatedEntity(Endpoint.BUILD_TYPES, createdBuildType);
+
+        // Проверка состояния UI
+        BuildTypePage.open(createdBuildType.getId())
+                .title.shouldHave(Condition.exactText(testData.getBuildType().getName()));
+    }
+
+    @Test(description = "User should not be able to create buildType without name", groups = {"Negative"})
+    public void userCannotCreateBuildTypeWithoutName() {
+        // Подготовка окружения
+        loginAs(testData.getUser());
+        var userCheckRequests = new CheckedRequests(Specifications.authSpec(testData.getUser()));
+
+        // Создание проекта через API
+        userCheckRequests.<Project>getRequest(PROJECTS).create(testData.getProject());
+        testDataStorage.addCreatedEntity(Endpoint.PROJECTS, testData.getProject());
+
+        // Взаимодействие с UI
+        CreateBuildTypePage.open(testData.getProject().getId())
+                .createForm(REPO_URL)
+                .errorMessageEmptyBuildTypeName("");
+    }
+}

--- a/src/test/java/com/example/teamcity/ui/CreateBuildTypeTest.java
+++ b/src/test/java/com/example/teamcity/ui/CreateBuildTypeTest.java
@@ -5,12 +5,20 @@ import com.example.teamcity.api.enums.Endpoint;
 import com.example.teamcity.api.models.BuildType;
 import com.example.teamcity.api.models.Project;
 import com.example.teamcity.api.requests.CheckedRequests;
+import com.example.teamcity.api.requests.UncheckedRequests;
 import com.example.teamcity.api.spec.Specifications;
 import com.example.teamcity.ui.pages.BuildTypePage;
 import com.example.teamcity.ui.pages.admin.CreateBuildTypePage;
+import io.restassured.response.Response;
 import org.testng.annotations.Test;
 
+import static com.example.teamcity.api.enums.Endpoint.BUILD_TYPES;
 import static com.example.teamcity.api.enums.Endpoint.PROJECTS;
+import static com.example.teamcity.api.generators.TestDataGenerator.generate;
+import static org.apache.http.HttpStatus.SC_NOT_FOUND;
+import static org.apache.http.HttpStatus.SC_OK;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
 
 @Test(groups = {"Regression"})
 public class CreateBuildTypeTest extends BaseUiTest {
@@ -32,29 +40,43 @@ public class CreateBuildTypeTest extends BaseUiTest {
                 .setupBuildType(testData.getBuildType().getName());
 
         // Получение созданного BuildType через API
-        var createdBuildType = superUserCheckRequests.<BuildType>getRequest(Endpoint.BUILD_TYPES)
+        var createdBuildType = superUserCheckRequests.<BuildType>getRequest(BUILD_TYPES)
                 .read("name:" + testData.getBuildType().getName());
         softy.assertNotNull(createdBuildType);
-        testDataStorage.addCreatedEntity(Endpoint.BUILD_TYPES, createdBuildType);
+        testDataStorage.addCreatedEntity(BUILD_TYPES, createdBuildType);
 
         // Проверка состояния UI
         BuildTypePage.open(createdBuildType.getId())
                 .title.shouldHave(Condition.exactText(testData.getBuildType().getName()));
     }
 
+
     @Test(description = "User should not be able to create buildType without name", groups = {"Negative"})
     public void userCannotCreateBuildTypeWithoutName() {
         // Подготовка окружения
         loginAs(testData.getUser());
-        var userCheckRequests = new CheckedRequests(Specifications.authSpec(testData.getUser()));
+        var buildType = generate(BuildType.class);
+        var userCheckRequests = new UncheckedRequests(Specifications.authSpec(testData.getUser()));
 
         // Создание проекта через API
-        userCheckRequests.<Project>getRequest(PROJECTS).create(testData.getProject());
+        Response projectCreationResponse = userCheckRequests.<Project>getRequest(PROJECTS).create(testData.getProject());
+        assertThat(projectCreationResponse.statusCode(), equalTo(SC_OK));
+
+        // Проверка, что проект действительно создан
+        var createdProject = superUserCheckRequests.<Project>getRequest(Endpoint.PROJECTS).read("name:" + testData.getProject().getName());
+        softy.assertNotNull(createdProject);
+
         testDataStorage.addCreatedEntity(Endpoint.PROJECTS, testData.getProject());
 
         // Взаимодействие с UI
         CreateBuildTypePage.open(testData.getProject().getId())
                 .createForm(REPO_URL)
                 .errorMessageEmptyBuildTypeName("");
+
+        // Попытка создать BuildType без имени на API уровне
+        Response createdBuildTypeResponse = userCheckRequests.getRequest(BUILD_TYPES).create(buildType);
+
+        // Проверка, что BuildType не создался на API уровне
+        assertThat(createdBuildTypeResponse.statusCode(), equalTo(SC_NOT_FOUND));
     }
 }


### PR DESCRIPTION
• BuildTypeElement, BuildConfigurationPage, BuildTypePage, и CreateBuildTypePage  - классы страниц и элементов UI для работы с созданием конфигураций сборок.
• Реализован тест CreateBuildTypeTest, содержащий два сценария:
      •	Позитивный сценарий userCreatesBuildType, который проверяет успешное создание BuildType с валидным именем.
      •Негативный сценарий userCannotCreateBuildTypeWithoutName, который проверяет, что невозможно создать BuildType без имени.
       •Добавлена настройка TestDataStorage.